### PR TITLE
feat: 홈 화면 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,22 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'com.google.code.gson:gson:2.8.6'
+
+	/* querydsl */
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslSrcDir = 'src/main/generated'
+clean {
+	delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/server/acode/domain/family/controller/HomeController.java
+++ b/src/main/java/server/acode/domain/family/controller/HomeController.java
@@ -1,0 +1,25 @@
+package server.acode.domain.family.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.acode.domain.family.dto.request.FragranceSearchCond;
+import server.acode.domain.family.dto.response.FragranceByCatgegory;
+import server.acode.domain.family.repository.FamilyRepository;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class HomeController {
+
+    private final FamilyRepository familyRepository;
+
+    @GetMapping("/home")
+    public List<FragranceByCatgegory> searchMemberV1(FragranceSearchCond condition){
+        return familyRepository.search(condition);
+    }
+
+}

--- a/src/main/java/server/acode/domain/family/controller/HomeController.java
+++ b/src/main/java/server/acode/domain/family/controller/HomeController.java
@@ -1,25 +1,36 @@
 package server.acode.domain.family.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.acode.domain.family.dto.request.FragranceSearchCond;
 import server.acode.domain.family.dto.response.FragranceByCatgegory;
-import server.acode.domain.family.repository.FamilyRepository;
+import server.acode.domain.family.service.HomeService;
+import server.acode.domain.ingredient.dto.response.IngredientOfTheDay;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Tag(name = "home", description = "홈 API")
 public class HomeController {
 
-    private final FamilyRepository familyRepository;
+    private final HomeService homeService;
 
+    @Operation(description = "계열별 향수 최대 6개")
     @GetMapping("/home")
-    public List<FragranceByCatgegory> searchMemberV1(FragranceSearchCond condition){
-        return familyRepository.search(condition);
+    public List<FragranceByCatgegory> searchV1(FragranceSearchCond condition){
+        return homeService.search(condition);
+    }
+
+    @Operation(description = "오늘의 추천 향료")
+    @GetMapping("/home/recommend")
+    public IngredientOfTheDay recommendV1(){
+        return homeService.recommendIngredient();
     }
 
 }

--- a/src/main/java/server/acode/domain/family/dto/request/FragranceSearchCond.java
+++ b/src/main/java/server/acode/domain/family/dto/request/FragranceSearchCond.java
@@ -1,0 +1,8 @@
+package server.acode.domain.family.dto.request;
+
+import lombok.Data;
+
+@Data
+public class FragranceSearchCond {
+    private String family;
+}

--- a/src/main/java/server/acode/domain/family/dto/response/FragranceByCatgegory.java
+++ b/src/main/java/server/acode/domain/family/dto/response/FragranceByCatgegory.java
@@ -5,14 +5,18 @@ import lombok.Data;
 
 @Data
 public class FragranceByCatgegory {
+    private Long fragranceId;
     private String fragranceName;
     private String brandName;
     private String style;
+    private String poster;
 
     @QueryProjection
-    public FragranceByCatgegory(String fragranceName, String brandName, String style){
+    public FragranceByCatgegory(Long fragranceId, String fragranceName, String brandName, String style, String poster){
+        this.fragranceId = fragranceId;
         this.fragranceName = fragranceName;
         this.brandName = brandName;
         this.style = style;
+        this.poster = poster;
     }
 }

--- a/src/main/java/server/acode/domain/family/dto/response/FragranceByCatgegory.java
+++ b/src/main/java/server/acode/domain/family/dto/response/FragranceByCatgegory.java
@@ -1,0 +1,18 @@
+package server.acode.domain.family.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class FragranceByCatgegory {
+    private String fragranceName;
+    private String brandName;
+    private String style;
+
+    @QueryProjection
+    public FragranceByCatgegory(String fragranceName, String brandName, String style){
+        this.fragranceName = fragranceName;
+        this.brandName = brandName;
+        this.style = style;
+    }
+}

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import server.acode.domain.family.entity.Family;
 
 @Repository
-public interface FamilyRepository extends JpaRepository<Family, Long> {
+public interface FamilyRepository extends JpaRepository<Family, Long>, FamilyRepositoryCustom {
 }

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
@@ -1,0 +1,10 @@
+package server.acode.domain.family.repository;
+
+import server.acode.domain.family.dto.request.FragranceSearchCond;
+import server.acode.domain.family.dto.response.FragranceByCatgegory;
+
+import java.util.List;
+
+public interface FamilyRepositoryCustom {
+    List<FragranceByCatgegory> search(FragranceSearchCond cond);
+}

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
@@ -1,10 +1,12 @@
 package server.acode.domain.family.repository;
 
+import org.springframework.stereotype.Repository;
 import server.acode.domain.family.dto.request.FragranceSearchCond;
 import server.acode.domain.family.dto.response.FragranceByCatgegory;
 
 import java.util.List;
 
+@Repository
 public interface FamilyRepositoryCustom {
     List<FragranceByCatgegory> search(FragranceSearchCond cond);
 }

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
@@ -31,14 +31,20 @@ public class FamilyRepositoryImpl implements FamilyRepositoryCustom{
     public List<FragranceByCatgegory> search(FragranceSearchCond cond) {
         return queryFactory
                 .select(new QFragranceByCatgegory(
+                        fragrance.id.as("fragranceId"),
                         fragrance.name.as("fragranceName"),
                         fragrance.korBrand.as("korBrand"),
-                        fragrance.style
+                        fragrance.style,
+                        fragrance.poster
                         ))
                 .from(fragranceFamily)
                 .join(fragranceFamily.family, family)
                 .join(fragranceFamily.fragrance, fragrance)
-                .where(family.korName.eq(cond.getFamily()))
+                .where(family.korName.eq(cond.getFamily()),
+                        fragrance.poster.isNotNull().and(fragrance.poster.ne(""))
+                )
+                .orderBy(fragrance.view.desc())
+                .limit(6)
                 .fetch();
     }
 }

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
@@ -1,0 +1,44 @@
+package server.acode.domain.family.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import server.acode.domain.family.dto.request.FragranceSearchCond;
+import server.acode.domain.family.dto.response.FragranceByCatgegory;
+import server.acode.domain.family.dto.response.QFragranceByCatgegory;
+import server.acode.domain.family.entity.QFamily;
+import server.acode.domain.family.entity.QFragranceFamily;
+import server.acode.domain.fragrance.entity.QFragrance;
+
+import java.util.List;
+
+import static server.acode.domain.family.entity.QFamily.*;
+import static server.acode.domain.family.entity.QFragranceFamily.*;
+import static server.acode.domain.fragrance.entity.QFragrance.*;
+
+@Repository
+public class FamilyRepositoryImpl implements FamilyRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    public FamilyRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+
+    @Override
+    public List<FragranceByCatgegory> search(FragranceSearchCond cond) {
+        return queryFactory
+                .select(new QFragranceByCatgegory(
+                        fragrance.name.as("fragranceName"),
+                        fragrance.korBrand.as("korBrand"),
+                        fragrance.style
+                        ))
+                .from(fragranceFamily)
+                .join(fragranceFamily.family, family)
+                .join(fragranceFamily.fragrance, fragrance)
+                .where(family.korName.eq(cond.getFamily()))
+                .fetch();
+    }
+}

--- a/src/main/java/server/acode/domain/family/service/HomeService.java
+++ b/src/main/java/server/acode/domain/family/service/HomeService.java
@@ -2,10 +2,47 @@ package server.acode.domain.family.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import server.acode.domain.family.dto.request.FragranceSearchCond;
+import server.acode.domain.family.dto.response.FragranceByCatgegory;
 import server.acode.domain.family.repository.FamilyRepository;
+import server.acode.domain.ingredient.dto.response.IngredientOfTheDay;
+import server.acode.domain.ingredient.repository.IngredientRepository;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class HomeService {
+
     private final FamilyRepository familyRepository;
+    private final IngredientRepository ingredientRepository;
+
+    public List<FragranceByCatgegory> search(FragranceSearchCond condition){
+
+        List<FragranceByCatgegory> result = familyRepository.search(condition); // 계열과 일치하는 향수 가져오기
+
+        result.forEach(fragrance -> {
+            String[] styles = fragrance.getStyle().split(", ");
+            List<String> limitedStyles = Arrays.stream(styles)
+                    .map(s -> "#" + s)
+                    .limit(3) // 최대 세 개의 스타일만 유지
+                    .collect(Collectors.toList());
+
+            String modifiedStyle = String.join(", ", limitedStyles);
+            fragrance.setStyle(modifiedStyle);
+        });
+
+        return result;
+    }
+
+    public IngredientOfTheDay recommendIngredient() {
+        List<IngredientOfTheDay> result = ingredientRepository.getTodayIngreient();
+
+        int index = LocalDate.now().getDayOfYear() % 5; // 오늘 날짜 기준으로 인덱스 생성
+
+        return result.get(index);
+    }
 }

--- a/src/main/java/server/acode/domain/family/service/HomeService.java
+++ b/src/main/java/server/acode/domain/family/service/HomeService.java
@@ -1,0 +1,11 @@
+package server.acode.domain.family.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import server.acode.domain.family.repository.FamilyRepository;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+    private final FamilyRepository familyRepository;
+}

--- a/src/main/java/server/acode/domain/ingredient/dto/response/IngredientOfTheDay.java
+++ b/src/main/java/server/acode/domain/ingredient/dto/response/IngredientOfTheDay.java
@@ -1,0 +1,16 @@
+package server.acode.domain.ingredient.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class IngredientOfTheDay {
+    private String ingredientName;
+    private String acode;
+
+    @QueryProjection
+    public IngredientOfTheDay(String ingredientName, String acode){
+        this.ingredientName = ingredientName;
+        this.acode = acode;
+    }
+}

--- a/src/main/java/server/acode/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/server/acode/domain/ingredient/repository/IngredientRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import server.acode.domain.ingredient.entity.Ingredient;
 
 @Repository
-public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+public interface IngredientRepository extends JpaRepository<Ingredient, Long>, IngredientRepositoryCustom {
 }

--- a/src/main/java/server/acode/domain/ingredient/repository/IngredientRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/ingredient/repository/IngredientRepositoryCustom.java
@@ -1,0 +1,11 @@
+package server.acode.domain.ingredient.repository;
+
+import org.springframework.stereotype.Repository;
+import server.acode.domain.ingredient.dto.response.IngredientOfTheDay;
+
+import java.util.List;
+
+@Repository
+public interface IngredientRepositoryCustom {
+    List<IngredientOfTheDay> getTodayIngreient();
+}

--- a/src/main/java/server/acode/domain/ingredient/repository/IngredientRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/ingredient/repository/IngredientRepositoryImpl.java
@@ -1,0 +1,31 @@
+package server.acode.domain.ingredient.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+import server.acode.domain.ingredient.dto.response.IngredientOfTheDay;
+import server.acode.domain.ingredient.dto.response.QIngredientOfTheDay;
+import server.acode.domain.ingredient.entity.QIngredient;
+
+import java.util.List;
+
+import static server.acode.domain.ingredient.entity.QIngredient.*;
+
+
+@Repository
+public class IngredientRepositoryImpl implements IngredientRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    public IngredientRepositoryImpl(EntityManager em) { this.queryFactory = new JPAQueryFactory(em); }
+    @Override
+    public List<IngredientOfTheDay> getTodayIngreient() {
+        return queryFactory
+                .select(new QIngredientOfTheDay(
+                        ingredient.engName.as("ingredientName"),
+                        ingredient.acode
+                ))
+                .from(ingredient)
+                .where(ingredient.id.in(5, 100, 80, 1, 102))
+                .fetch();
+    }
+}

--- a/src/test/java/server/acode/domain/family/repository/FamilyRepositoryTest.java
+++ b/src/test/java/server/acode/domain/family/repository/FamilyRepositoryTest.java
@@ -1,0 +1,23 @@
+package server.acode.domain.family.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class FamilyRepositoryTest {
+    @Autowired
+    EntityManager em;
+    @Autowired FamilyRepository familyRepository;
+
+    @Test
+    public void searchTest(){
+
+    }
+
+}


### PR DESCRIPTION
# PR

## PR 요약

- 오늘의 추천 향료
  - 데모데이 발표에 보이기로 선정된 5개의 향료 중 오늘 날짜에 따라 '오늘의 추천 향료'를 보내도록 하였습니다
- 계열별 향수 최대 6개
  - poster가 있고 계열 이름이 일치하는 향수들 중 조회수 내림차순으로 6개만 조회해오도록 하였습니다
  - style 이름 변경은 조회해온 뒤 Service 단에서 수정하였습니다

## 변경된 점
- FamilyRepository, IngredientRepository 두 개의 Repository 다 Querydsl 사용하기 위해 사용자 정의 인터페이스 정의 후 상속받도록 하였습니다

## 이슈 번호
- #9 
