### PR TITLE
feat: 계열에 맞는 향수/ 계열 반환 #23

### DIFF
--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryCustom.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import server.acode.domain.family.dto.request.FragranceFilterCond;
 import server.acode.domain.family.dto.response.DisplayFragrance;
 import server.acode.domain.family.dto.response.HomeFragrance;
+import server.acode.domain.fragrance.dto.response.ExtractFamily;
 
 import java.util.List;
 
@@ -14,4 +15,6 @@ public interface FamilyRepositoryCustom {
     List<HomeFragrance> search(String familyCond);
     Page<DisplayFragrance> searchByFilter(FragranceFilterCond cond, String additionalFamily, Pageable pageable);
     Page<DisplayFragrance> searchByIngredient(String ingredientName, Pageable pageable);
+
+    List<ExtractFamily> extractFamilies(List<Long> fragranceIdList);
 }

--- a/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/family/repository/FamilyRepositoryImpl.java
@@ -16,6 +16,8 @@ import server.acode.domain.family.dto.response.QDisplayFragrance;
 import server.acode.domain.family.dto.response.QHomeFragrance;
 import server.acode.domain.family.entity.QFamily;
 import server.acode.domain.family.entity.QFragranceFamily;
+import server.acode.domain.fragrance.dto.response.ExtractFamily;
+import server.acode.domain.fragrance.dto.response.QExtractFamily;
 import server.acode.domain.fragrance.entity.QFragrance;
 
 
@@ -124,6 +126,20 @@ public class FamilyRepositoryImpl implements FamilyRepositoryCustom{
         long total = results.getTotal();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<ExtractFamily> extractFamilies(List<Long> fragranceIdList){
+        return queryFactory.select(new QExtractFamily(
+                family.korName,
+                family.engName,
+                family.summary,
+                family.icon,
+                family.keyword
+        ))
+                .from(family)
+                .where(family.id.in(fragranceIdList))
+                .fetch();
     }
 
     private BooleanExpression brandNameEq(String brandName) {

--- a/src/main/java/server/acode/domain/family/repository/FragranceFamilyRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/family/repository/FragranceFamilyRepositoryCustom.java
@@ -2,6 +2,7 @@ package server.acode.domain.family.repository;
 
 import org.springframework.stereotype.Repository;
 import server.acode.domain.family.dto.SimilarFragranceOrCond;
+import server.acode.domain.fragrance.dto.response.ExtractFragrance;
 import server.acode.domain.fragrance.dto.response.FamilyCountDto;
 import server.acode.domain.fragrance.dto.response.FragranceInfo;
 
@@ -20,4 +21,6 @@ public interface FragranceFamilyRepositoryCustom {
     List<Long> extractByMainFamily(String mainFamilyCond, List<Long> fragranceIdList);
 
     List<FamilyCountDto> countFamily(List<Long> fragranceIdList);
+
+    List<ExtractFragrance> extractFragrance(List<Long> familyIdList);
 }

--- a/src/main/java/server/acode/domain/family/repository/FragranceFamilyRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/family/repository/FragranceFamilyRepositoryImpl.java
@@ -1,16 +1,14 @@
 package server.acode.domain.family.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 import server.acode.domain.family.dto.SimilarFragranceOrCond;
 import server.acode.domain.family.entity.QFragranceFamily;
-import server.acode.domain.fragrance.dto.response.FamilyCountDto;
-import server.acode.domain.fragrance.dto.response.FragranceInfo;
-import server.acode.domain.fragrance.dto.response.QFamilyCountDto;
-import server.acode.domain.fragrance.dto.response.QFragranceInfo;
+import server.acode.domain.fragrance.dto.response.*;
 import server.acode.domain.fragrance.entity.QFragrance;
 
 import java.util.List;
@@ -141,4 +139,22 @@ public class FragranceFamilyRepositoryImpl implements FragranceFamilyRepositoryC
                 .orderBy(fragranceFamily.family.count().desc())
                 .fetch();
     }
+
+    @Override
+    public List<ExtractFragrance> extractFragrance(List<Long> familyIdList) {
+        return queryFactory
+                .selectDistinct(new QExtractFragrance(
+                        fragrance.id,
+                        fragrance.name,
+                        fragrance.brand.korName,
+                        fragranceFamily.family.korName,
+                        fragrance.thumbnail
+                        )
+                )
+                .from(fragranceFamily)
+                .where(fragranceFamily.family.id.in(familyIdList))
+                .fetch();
+    }
+
+
 }

--- a/src/main/java/server/acode/domain/fragrance/controller/ExtractController.java
+++ b/src/main/java/server/acode/domain/fragrance/controller/ExtractController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import server.acode.domain.fragrance.dto.request.KeywordCond;
+import server.acode.domain.fragrance.dto.response.ExtractResponse;
 import server.acode.domain.fragrance.service.ExtractService;
 
 @RestController
@@ -16,9 +17,9 @@ public class ExtractController {
     private final ExtractService extractService;
 
     @Operation(summary = "매칭 테스트",
-            description = "아직 미완성 입니다")    
-    @GetMapping // 나중에 POST로ㅎ
-    public ResponseEntity<?> extractFamily(@RequestBody KeywordCond cond) {
+            description = "계열 최대 세 개, 추천 향수 최대 다섯 개(임의) 리턴됩니다")
+    @PostMapping
+    public ExtractResponse extractFamily(@RequestBody KeywordCond cond) {
         return extractService.extractFamily(cond);
     }
 }

--- a/src/main/java/server/acode/domain/fragrance/dto/response/ExtractFamily.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/ExtractFamily.java
@@ -1,0 +1,25 @@
+package server.acode.domain.fragrance.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+@Data
+public class ExtractFamily {
+    private String familyKorName;
+    private String familyEngName;
+    private String summary;
+    private String icon;
+    private List<String> keyword;
+
+
+    @QueryProjection
+    public ExtractFamily(String familyKorName, String familyEngName, String summary, String icon, String keyword){
+        this.familyKorName = familyKorName;
+        this.familyEngName = familyEngName;
+        this.summary = summary;
+        this.icon = icon;
+        this.keyword = Arrays.asList(keyword.split(", "));
+    }
+}

--- a/src/main/java/server/acode/domain/fragrance/dto/response/ExtractFragrance.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/ExtractFragrance.java
@@ -1,0 +1,24 @@
+package server.acode.domain.fragrance.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ExtractFragrance {
+    private Long fragranceId;
+    private String fragranceName;
+    private String brandName;
+    private String familyName;
+    private String thumbnail;
+
+    @QueryProjection
+    public ExtractFragrance(Long fragranceId, String fragranceName, String  brandName, String familyName, String thumbnail){
+        this.fragranceId =fragranceId;
+        this.fragranceName =fragranceName;
+        this.brandName = brandName;
+        this.familyName = familyName;
+        this.thumbnail = thumbnail;
+    }
+}

--- a/src/main/java/server/acode/domain/fragrance/dto/response/ExtractResponse.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/ExtractResponse.java
@@ -1,0 +1,16 @@
+package server.acode.domain.fragrance.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ExtractResponse {
+    private List<ExtractFamily> families;
+    private List<ExtractFragrance> fragrances;
+
+    public ExtractResponse(List<ExtractFamily> families, List<ExtractFragrance> fragrances){
+        this.families = families;
+        this.fragrances =fragrances;
+    }
+}

--- a/src/main/java/server/acode/domain/fragrance/repository/FragranceRepositoryCustom.java
+++ b/src/main/java/server/acode/domain/fragrance/repository/FragranceRepositoryCustom.java
@@ -2,6 +2,7 @@ package server.acode.domain.fragrance.repository;
 
 import org.springframework.stereotype.Repository;
 import server.acode.domain.fragrance.dto.request.KeywordCond;
+import server.acode.domain.fragrance.dto.response.ExtractFamily;
 
 import java.util.List;
 

--- a/src/main/java/server/acode/domain/fragrance/repository/FragranceRepositoryImpl.java
+++ b/src/main/java/server/acode/domain/fragrance/repository/FragranceRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
+import server.acode.domain.fragrance.dto.response.ExtractFamily;
+import server.acode.domain.fragrance.dto.response.QExtractFamily;
 import server.acode.domain.fragrance.entity.Concentration;
 
 import java.util.List;
@@ -45,6 +47,8 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
                 )
                 .fetch();
     }
+
+
 
 
     private BooleanExpression scentContainsIgnoreCase(String scent) {


### PR DESCRIPTION
# PR

## PR 요약
- 계열 중 세 개 랜덤 추출 후 계열과 일치하는 향수 최대 다섯 개(임의)리스트, 계열 상세 리스트 리턴하였습니다.

## 변경된 점
- changes

## 이슈 번호
- #23
