### PR TITLE
chore: 구매 링크 api 수정 

### DIFF
--- a/src/main/java/server/acode/domain/fragrance/dto/response/GetFragrancePurchase.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/GetFragrancePurchase.java
@@ -1,26 +1,15 @@
 package server.acode.domain.fragrance.dto.response;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import server.acode.domain.fragrance.entity.Fragrance;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class GetFragrancePurchase {
-    private String link1; // 구매 링크 url
-    private String link2;
-    private String link3;
-
-    public GetFragrancePurchase(String link1, String link2, String link3) {
-        this.link1 = link1;
-        this.link2 = link2;
-        this.link3 = link3;
-    }
-
-    public static GetFragrancePurchase from(Fragrance fragrance) {
-        return new GetFragrancePurchase(
-                fragrance.getLink1(), fragrance.getLink2(), fragrance.getLink3()
-        );
-    }
+    private boolean isSoldOut;
+    private List<PurchaseInfo> purchaseList;
 }

--- a/src/main/java/server/acode/domain/fragrance/dto/response/GetFragrancePurchase.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/GetFragrancePurchase.java
@@ -11,5 +11,7 @@ import java.util.List;
 @Builder
 public class GetFragrancePurchase {
     private boolean isSoldOut;
+    private String fragranceName;
+    private String brandName;
     private List<PurchaseInfo> purchaseList;
 }

--- a/src/main/java/server/acode/domain/fragrance/dto/response/PurchaseInfo.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/PurchaseInfo.java
@@ -8,6 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class PurchaseInfo {
+    private String title;
     private String link;
     private String image;
 }

--- a/src/main/java/server/acode/domain/fragrance/dto/response/PurchaseInfo.java
+++ b/src/main/java/server/acode/domain/fragrance/dto/response/PurchaseInfo.java
@@ -1,0 +1,13 @@
+package server.acode.domain.fragrance.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseInfo {
+    private String link;
+    private String image;
+}

--- a/src/main/java/server/acode/domain/fragrance/service/FragranceService.java
+++ b/src/main/java/server/acode/domain/fragrance/service/FragranceService.java
@@ -392,85 +392,77 @@ public class FragranceService {
         boolean isSoldOut = false;
         if (!hasText(fragrance.getLink1())) {
             isSoldOut = true;
-            return GetFragrancePurchase.builder().isSoldOut(isSoldOut).build();
+            return GetFragrancePurchase.builder()
+                    .isSoldOut(isSoldOut)
+                    .fragranceName(fragrance.getName())
+                    .brandName(fragrance.getBrand().getKorName())
+                    .build();
         }
 
         List<PurchaseInfo> purchaseList = new ArrayList<>();
-        PurchaseInfo purchaseInfo1 = PurchaseInfo.builder().link(fragrance.getLink1()).build();
-        if (purchaseInfo1.getLink().startsWith("https://www.sivillage")) {
-            purchaseInfo1.setImage(siVillage);
-        } else if (purchaseInfo1.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
-            purchaseInfo1.setImage(fragrance.getBrand().getRoundImg());
-        } else if (fragrance.getBrand().getId() == 5L) { // 조말론
-            Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
-            purchaseInfo1.setImage(brand.getRoundImg());
-        } else if (purchaseInfo1.getLink().startsWith("https://www.lotteon")) {
-            purchaseInfo1.setImage(lotteOn);
-        } else if (purchaseInfo1.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
-            purchaseInfo1.setImage(lg);
-        } else if (purchaseInfo1.getLink().startsWith("https://www.kurly")) {
-            purchaseInfo1.setImage(kurly);
-        } else {
-            throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
-        }
+        PurchaseInfo purchaseInfo1 = setPurchaseInfo(fragrance, fragrance.getLink1());
         purchaseList.add(purchaseInfo1);
 
         if (hasText(fragrance.getLink2())) {
-            PurchaseInfo purchaseInfo2 = PurchaseInfo.builder().link(fragrance.getLink2()).build();
-            if (purchaseInfo2.getLink().startsWith("https://www.sivillage")) {
-                purchaseInfo2.setImage(siVillage);
-            } else if (purchaseInfo2.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
-                purchaseInfo2.setImage(fragrance.getBrand().getRoundImg());
-            } else if (fragrance.getBrand().getId() == 5L) { // 조말론
-                Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
-                purchaseInfo2.setImage(brand.getRoundImg());
-            } else if (purchaseInfo2.getLink().startsWith("https://www.lotteon")) {
-                purchaseInfo2.setImage(lotteOn);
-            } else if (purchaseInfo2.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
-                purchaseInfo2.setImage(lg);
-            } else if (purchaseInfo2.getLink().startsWith("https://www.kurly")) {
-                purchaseInfo2.setImage(kurly);
-            } else {
-                throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
-            }
+            PurchaseInfo purchaseInfo2 = setPurchaseInfo(fragrance, fragrance.getLink2());
             purchaseList.add(purchaseInfo2);
         } else {
             return GetFragrancePurchase.builder()
                     .isSoldOut(isSoldOut)
+                    .fragranceName(fragrance.getName())
+                    .brandName(fragrance.getBrand().getKorName())
                     .purchaseList(purchaseList)
                     .build();
         }
 
         if (hasText(fragrance.getLink3())) {
-            PurchaseInfo purchaseInfo3 = PurchaseInfo.builder().link(fragrance.getLink3()).build();
-            if (purchaseInfo3.getLink().startsWith("https://www.sivillage")) {
-                purchaseInfo3.setImage(siVillage);
-            } else if (purchaseInfo3.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
-                purchaseInfo3.setImage(fragrance.getBrand().getRoundImg());
-            } else if (fragrance.getBrand().getId() == 5L) { // 조말론
-                Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
-                purchaseInfo3.setImage(brand.getRoundImg());
-            } else if (purchaseInfo3.getLink().startsWith("https://www.lotteon")) {
-                purchaseInfo3.setImage(lotteOn);
-            } else if (purchaseInfo3.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
-                purchaseInfo3.setImage(lg);
-            } else if (purchaseInfo3.getLink().startsWith("https://www.kurly")) {
-                purchaseInfo3.setImage(kurly);
-            } else {
-                throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
-            }
+            PurchaseInfo purchaseInfo3 = setPurchaseInfo(fragrance, fragrance.getLink3());
             purchaseList.add(purchaseInfo3);
         } else {
             return GetFragrancePurchase.builder()
                     .isSoldOut(isSoldOut)
+                    .fragranceName(fragrance.getName())
+                    .brandName(fragrance.getBrand().getKorName())
                     .purchaseList(purchaseList)
                     .build();
         }
 
         return GetFragrancePurchase.builder()
                 .isSoldOut(isSoldOut)
+                .fragranceName(fragrance.getName())
+                .brandName(fragrance.getBrand().getKorName())
                 .purchaseList(purchaseList)
                 .build();
+    }
+
+    private PurchaseInfo setPurchaseInfo(Fragrance fragrance, String link) {
+        PurchaseInfo purchaseInfo = PurchaseInfo.builder().link(link).build();
+
+        if (purchaseInfo.getLink().startsWith("https://www.sivillage")) {
+            purchaseInfo.setImage(siVillage);
+            purchaseInfo.setTitle("S.I.VILLAGE 신세계인터내셔날 공식몰");
+        } else if (purchaseInfo.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
+            purchaseInfo.setImage(fragrance.getBrand().getRoundImg());
+//            StringBuilder sb = new StringBuilder(fragrance.getBrand().getEngName()).append(" ").append(fragrance.getBrand().getKorName());
+            purchaseInfo.setTitle(fragrance.getBrand().getEngName() + " " + fragrance.getBrand().getKorName());
+        } else if (fragrance.getBrand().getId() == 5L) { // 조말론
+            Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
+            purchaseInfo.setImage(brand.getRoundImg());
+            purchaseInfo.setTitle("JO MALONE LONDON 조말론 런던");
+        } else if (purchaseInfo.getLink().startsWith("https://www.lotteon")) {
+            purchaseInfo.setImage(lotteOn);
+            purchaseInfo.setTitle("LOTTE ON 롯데온");
+        } else if (purchaseInfo.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
+            purchaseInfo.setImage(lg);
+            purchaseInfo.setTitle("LG생활건강");
+        } else if (purchaseInfo.getLink().startsWith("https://www.kurly")) {
+            purchaseInfo.setImage(kurly);
+            purchaseInfo.setTitle("KURLY 컬리");
+        } else {
+            throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+
+        return purchaseInfo;
     }
 
 

--- a/src/main/java/server/acode/domain/fragrance/service/FragranceService.java
+++ b/src/main/java/server/acode/domain/fragrance/service/FragranceService.java
@@ -1,6 +1,7 @@
 package server.acode.domain.fragrance.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -10,8 +11,10 @@ import server.acode.domain.family.dto.SimilarFragranceOrCond;
 import server.acode.domain.family.entity.Family;
 import server.acode.domain.family.repository.FragranceFamilyRepository;
 import server.acode.domain.fragrance.dto.response.*;
+import server.acode.domain.fragrance.entity.Brand;
 import server.acode.domain.fragrance.entity.Capacity;
 import server.acode.domain.fragrance.entity.Fragrance;
+import server.acode.domain.fragrance.repository.BrandRepository;
 import server.acode.domain.fragrance.repository.CapacityRepository;
 import server.acode.domain.fragrance.repository.FragranceRepository;
 import server.acode.domain.ingredient.entity.Ingredient;
@@ -36,6 +39,8 @@ import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.springframework.util.StringUtils.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -58,6 +63,20 @@ public class FragranceService {
     private final ReviewStyleRepository reviewStyleRepository;
 
     private final UserRepository userRepository;
+
+    private final BrandRepository brandRepository;
+
+    @Value("${store.image.siVillage}")
+    String siVillage;
+
+    @Value("${store.image.lotteOn}")
+    String lotteOn;
+
+    @Value("${store.image.kurly}")
+    String kurly;
+
+    @Value("${store.image.lg}")
+    String lg;
 
 
     @Transactional
@@ -369,7 +388,89 @@ public class FragranceService {
     public GetFragrancePurchase getFragrancePurchase(Long fragranceId) {
         Fragrance fragrance = fragranceRepository.findById(fragranceId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FRAGRANCE_NOT_FOUND));
-        return GetFragrancePurchase.from(fragrance);
+
+        boolean isSoldOut = false;
+        if (!hasText(fragrance.getLink1())) {
+            isSoldOut = true;
+            return GetFragrancePurchase.builder().isSoldOut(isSoldOut).build();
+        }
+
+        List<PurchaseInfo> purchaseList = new ArrayList<>();
+        PurchaseInfo purchaseInfo1 = PurchaseInfo.builder().link(fragrance.getLink1()).build();
+        if (purchaseInfo1.getLink().startsWith("https://www.sivillage")) {
+            purchaseInfo1.setImage(siVillage);
+        } else if (purchaseInfo1.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
+            purchaseInfo1.setImage(fragrance.getBrand().getRoundImg());
+        } else if (fragrance.getBrand().getId() == 5L) { // 조말론
+            Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
+            purchaseInfo1.setImage(brand.getRoundImg());
+        } else if (purchaseInfo1.getLink().startsWith("https://www.lotteon")) {
+            purchaseInfo1.setImage(lotteOn);
+        } else if (purchaseInfo1.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
+            purchaseInfo1.setImage(lg);
+        } else if (purchaseInfo1.getLink().startsWith("https://www.kurly")) {
+            purchaseInfo1.setImage(kurly);
+        } else {
+            throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+        purchaseList.add(purchaseInfo1);
+
+        if (hasText(fragrance.getLink2())) {
+            PurchaseInfo purchaseInfo2 = PurchaseInfo.builder().link(fragrance.getLink2()).build();
+            if (purchaseInfo2.getLink().startsWith("https://www.sivillage")) {
+                purchaseInfo2.setImage(siVillage);
+            } else if (purchaseInfo2.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
+                purchaseInfo2.setImage(fragrance.getBrand().getRoundImg());
+            } else if (fragrance.getBrand().getId() == 5L) { // 조말론
+                Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
+                purchaseInfo2.setImage(brand.getRoundImg());
+            } else if (purchaseInfo2.getLink().startsWith("https://www.lotteon")) {
+                purchaseInfo2.setImage(lotteOn);
+            } else if (purchaseInfo2.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
+                purchaseInfo2.setImage(lg);
+            } else if (purchaseInfo2.getLink().startsWith("https://www.kurly")) {
+                purchaseInfo2.setImage(kurly);
+            } else {
+                throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+            }
+            purchaseList.add(purchaseInfo2);
+        } else {
+            return GetFragrancePurchase.builder()
+                    .isSoldOut(isSoldOut)
+                    .purchaseList(purchaseList)
+                    .build();
+        }
+
+        if (hasText(fragrance.getLink3())) {
+            PurchaseInfo purchaseInfo3 = PurchaseInfo.builder().link(fragrance.getLink3()).build();
+            if (purchaseInfo3.getLink().startsWith("https://www.sivillage")) {
+                purchaseInfo3.setImage(siVillage);
+            } else if (purchaseInfo3.getLink().contains(fragrance.getBrand().getEngName().replace(" ", "").toLowerCase())) { // 공홈
+                purchaseInfo3.setImage(fragrance.getBrand().getRoundImg());
+            } else if (fragrance.getBrand().getId() == 5L) { // 조말론
+                Brand brand = brandRepository.findById(5L).orElseThrow(() -> new CustomException(ErrorCode.BRAND_NOT_FOUND));
+                purchaseInfo3.setImage(brand.getRoundImg());
+            } else if (purchaseInfo3.getLink().startsWith("https://www.lotteon")) {
+                purchaseInfo3.setImage(lotteOn);
+            } else if (purchaseInfo3.getLink().startsWith("https://brand.naver.com/lg_perfumery")) {
+                purchaseInfo3.setImage(lg);
+            } else if (purchaseInfo3.getLink().startsWith("https://www.kurly")) {
+                purchaseInfo3.setImage(kurly);
+            } else {
+                throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+            }
+            purchaseList.add(purchaseInfo3);
+        } else {
+            return GetFragrancePurchase.builder()
+                    .isSoldOut(isSoldOut)
+                    .purchaseList(purchaseList)
+                    .build();
+        }
+
+        return GetFragrancePurchase.builder()
+                .isSoldOut(isSoldOut)
+                .purchaseList(purchaseList)
+                .build();
     }
 
 

--- a/src/main/java/server/acode/global/common/ErrorCode.java
+++ b/src/main/java/server/acode/global/common/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     REVIEW_LONGEVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자에게 문의 바랍니다."),
     REVIEW_INTENSITY_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자에게 문의 바랍니다."),
     REVIEW_STYLE_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자에게 문의 바랍니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자에게 문의 바랍니다"),
 
 
     /* 409 CONFLICT */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,10 @@ cloud:
 
 presignedUrlDuration: ${PRESIGNED_URL_DURATION}
 kakaoAdminKey: ${KAKAO_ADMIN_KEY}
+
+store:
+  image:
+    siVillage: ${STORE_IMAGE_SIVILLAGE}
+    lotteOn: ${STORE_IMAGE_LOTTEON}
+    kurly: ${STORE_IMAGE_KURLY}
+    lg: ${STORE_IMAGE_LG}


### PR DESCRIPTION
# PR

## PR 요약
* 구매 링크 api 수정

## 변경된 점
* 기존 구매 링크만 보내던 방식에서
    구매 링크와 이미지를 같이 보내고, 품절 여부를 확인할 수 있도록 수정
* 엔티티에 구매 링크를 컬럼으로 저장해두었는데 
    추후 엔티티를 분리하는 등의 리팩토링을 거치면 좋을 것 같다 

## 이슈 번호
* #7 
